### PR TITLE
Fix solute name truncation

### DIFF
--- a/martignac/parsers/gromacs_forcefields.py
+++ b/martignac/parsers/gromacs_forcefields.py
@@ -529,7 +529,7 @@ def get_molecule_from_name(
     """
     particle_names = molecule_name.split(",")[0].split()
     if molecule_label is None:
-        molecule_label = "".join(particle_names)[:5]
+        molecule_label = "".join(particle_names)[:4]
     # Construct list of atoms
     atoms = [
         _get_atom_from_string(name, i, molecule_label)


### PR DESCRIPTION
Initially, the solute name gets truncated to five characters. During the system preparation the _.gro_ files get converted to _.pdb_ files which truncates the solute name to four characters. Afterward, the method `update_counts_against_gro` can't match the molecule names anymore and sets the molecule count to zero. Truncating the solute name to four characters in the beginning, prevents this problem.