### PR TITLE
Load config.yaml and .env from current working directory

### DIFF
--- a/martignac/__init__.py
+++ b/martignac/__init__.py
@@ -12,14 +12,15 @@ from martignac.logging import logger
 
 __all__ = ["config"]
 
-if os.environ.get('MARTIGNACDIR') is None:
-    os.environ['MARTIGNACDIR'] = str(Path.cwd())
+if os.environ.get("MARTIGNACDIR") is None:
+    os.environ["MARTIGNACDIR"] = str(Path.cwd())
 CONFIG = confuse.Configuration("martignac", __name__)
 LOGGING_LEVEL = "INFO"
 logger.setLevel(LOGGING_LEVEL)
 
 if Path(CONFIG.config_dir()).resolve() == Path(__file__).parent.resolve():
-    logger.warning('You are currently using the default configuration of Martignac.')
+    logger.warning("You are currently using the default configuration of Martignac.")
+
 
 def config() -> Configuration:
     return CONFIG

--- a/martignac/nomad/utils.py
+++ b/martignac/nomad/utils.py
@@ -13,7 +13,7 @@ from requests_toolbelt.multipart.encoder import MultipartEncoder
 
 logger = logging.getLogger(__name__)
 
-environ = AutoConfig(search_path=os.environ['MARTIGNACDIR'])
+environ = AutoConfig(search_path=os.environ["MARTIGNACDIR"])
 NOMAD_USERNAME = environ("NOMAD_USERNAME")
 NOMAD_PASSWORD = environ("NOMAD_PASSWORD")
 NOMAD_PROD_URL = "https://nomad-lab.eu/prod/v1/api/v1"


### PR DESCRIPTION
Currently, it is not possible to specify a custom _config.yaml_ file. This is useful if one runs multiple projects from different external directories. Moreover, if the program is run from an external directory, it cannot find the .env file to load the NOMAD credentials.

By setting a env-variable `MARTIGNACDIR` to the current working directory, the **confuse** library finds _config.yaml_ files in the current working directory. It only falls back to the _default_config.yaml_ in the martignac source directory if such a _config.yaml_ cannot be found.

By also specifying the search path of the `AutoConfig` class from the **decouple** library, it always looks for _.env_ files in the current working directory and its parent directories instead of the directory of the martignac source files.