### PR TITLE
Check upload to NOMAD for subworkflows

### DIFF
--- a/martignac/workflows/solute_in_bilayer_umbrella.py
+++ b/martignac/workflows/solute_in_bilayer_umbrella.py
@@ -138,11 +138,12 @@ def highest_depth_job(jobs) -> Job:
 
 @SoluteInBilayerUmbrellaFlow.label
 def solute_generated(job) -> bool:
+    solute_job: Job = get_solute_job(job)
     return (
         solute_gen_name in job.doc
         and job.doc[solute_gen_name].get("solute_gro")
         and job.doc[solute_gen_name].get("solute_top")
-        and uploaded_to_nomad(job)
+        and uploaded_to_nomad(solute_job)
     )
 
 
@@ -172,10 +173,11 @@ def generated_box_pdb(job):
 
 @SoluteInBilayerUmbrellaFlow.label
 def bilayer_generated(job) -> bool:
+    solvent_job: Job = get_solvent_job(job)
     return (
         bilayer_gen_name in job.doc
         and job.doc[bilayer_gen_name].get("bilayer_gro")
-        and uploaded_to_nomad(job)
+        and uploaded_to_nomad(solvent_job)
     )
 
 

--- a/martignac/workflows/solute_in_solvent_alchemical.py
+++ b/martignac/workflows/solute_in_solvent_alchemical.py
@@ -123,8 +123,16 @@ def lowest_lambda_job(jobs) -> Job:
 
 @SoluteInSolventAlchemicalFlow.label
 def system_prepared(job) -> bool:
+    solute_job: Job = get_solute_job(job)
+    solvent_job: Job = get_solvent_job(job)
+    solvation_job: Job = get_solvation_job(job)
     if project_name in job.document:
-        return job.doc[project_name].get("system_prepared", False)
+        return (
+            job.doc[project_name].get("system_prepared", False)
+            and uploaded_to_nomad(solute_job)
+            and uploaded_to_nomad(solvent_job)
+            and uploaded_to_nomad(solvation_job)
+        )
     return False
 
 

--- a/martignac/workflows/solute_in_solvent_generation.py
+++ b/martignac/workflows/solute_in_solvent_generation.py
@@ -79,16 +79,23 @@ solvent_gen_name = SolventGenFlow.class_name()
 
 @SoluteInSolventGenFlow.label
 def solute_generated(job) -> bool:
+    solute_job: Job = get_solute_job(job)
     return (
         solute_gen_name in job.doc
         and job.doc[solute_gen_name].get("solute_gro")
         and job.doc[solute_gen_name].get("solute_top")
+        and uploaded_to_nomad(solute_job)
     )
 
 
 @SoluteInSolventGenFlow.label
 def solvent_generated(job) -> bool:
-    return solvent_gen_name in job.doc and job.doc[solvent_gen_name].get("solvent_gro")
+    solvent_job: Job = get_solvent_job(job)
+    return (
+        solvent_gen_name in job.doc
+        and job.doc[solvent_gen_name].get("solvent_gro")
+        and uploaded_to_nomad(solvent_job)
+    )
 
 
 @SoluteInSolventGenFlow.pre(fetched_from_nomad)


### PR DESCRIPTION
When running a `solute_in_bilayer` workflow, it only checks if the relevant files from sub-workflows are present, but not if there are already uploaded. By adding these `uploaded_to_nomad` check, it also revisits sub-workflows if all necessary files already exist. Thus, when reuploading files to, e.g., a new dataset the subworkflow files are also uploaded.