### PR TITLE
Check if file exists before symlinking it

### DIFF
--- a/martignac/utils/martini_flow_projects.py
+++ b/martignac/utils/martini_flow_projects.py
@@ -578,6 +578,8 @@ def symlink_itp_and_mdp_files(job: Job) -> None:
     def symlink_or_copy(files, _path):
         for file in files:
             if not job.isfile(os.path.basename(file)):
+                if not os.path.isfile(f"{_path}/{file}"):
+                    raise FileNotFoundError(f"{_path}/{file} not found")
                 if project.allow_symlinks:
                     os.symlink(f"{_path}/{file}", job.fn(os.path.basename(file)))
                 else:


### PR DESCRIPTION
To prevent errors caused by incorrect input file paths in large config files, this update adds a check for the existence of input files before creating symlinks. This ensures that any issues are caught early, providing a clear error message for missing files, instead of a confusing error later when the symlinked file is accessed.